### PR TITLE
Fix(merge): Correct relationship provenance merging for merged CUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ neo4j-admin database import full \
     --nodes=Concept-ID="/path/to/pyNeoUmlsSyncer/csv_output/nodes_concepts.csv" \
     --nodes=Code-ID="/path/to/pyNeoUmlsSyncer/csv_output/nodes_codes.csv" \
     --relationships=HAS_CODE="/path/to/pyNeoUmlsSyncer/csv_output/rels_has_code.csv" \
-    --relationships=RELATED="/path/to/pyNeoUmlsSyncer/csv_output/rels_inter_concept.csv" \
+    --relationships="/path/to/pyNeoUmlsSyncer/csv_output/rels_inter_concept.csv" \
     --overwrite-destination=true \
     neo4j
 ```
@@ -107,9 +107,8 @@ The generated Labeled Property Graph (LPG) has the following structure:
 
 -   **Relationships**:
     -   `(:Concept)-[:HAS_CODE]->(:Code)`: Connects a concept to its source codes.
-    -   `(:Concept)-[:RELATED]->(:Concept)`: A generic relationship connecting two concepts.
+    -   `(:Concept)-[:biolink:treats]->(:Concept)`: Inter-concept relationships use the mapped Biolink Predicate as the relationship **type**.
         - Properties:
-            - `type`: The mapped Biolink Predicate (e.g., `biolink:treats`).
             - `source_rela`: The original UMLS RELA/REL value.
             - `asserted_by_sabs`: A list of source vocabularies asserting the relationship.
             - `last_seen_version`: The UMLS release this relationship was last seen in.

--- a/src/pyNeoUmlsSyncer/delta_strategy.py
+++ b/src/pyNeoUmlsSyncer/delta_strategy.py
@@ -67,19 +67,47 @@ class DeltaStrategy:
         # MERGEDCUI.RRF contains CUI_OLD|CUI_NEW
         merges = [row for row in csv.reader(merged_cui_file.open('r'), delimiter='|')]
 
-        # Using apoc.refactor.mergeNodes is the most robust way to handle this.
-        # It correctly merges properties and migrates relationships.
+        # This query manually migrates relationships to ensure provenance is correctly merged,
+        # fulfilling the specific FRD requirement that `apoc.refactor.mergeNodes` cannot.
         query = """
         CALL apoc.periodic.iterate(
           'UNWIND $merges AS merge_op
            MATCH (old:Concept {cui: merge_op[0]}), (new:Concept {cui: merge_op[1]})
            RETURN old, new',
-          'CALL apoc.refactor.mergeNodes([old], new, {properties: "combine", mergeRels: true}) YIELD node
-           DETACH DELETE old',
-          {batchSize: 100, parallel: false, params: {merges: $merges}}
+          '
+            // Migrate outgoing relationships
+            CALL {
+                WITH old, new
+                MATCH (old)-[r]->(target:Concept) WHERE target <> new
+                CALL apoc.merge.relationship(new, type(r), {source_rela: r.source_rela}, {}, target) YIELD rel AS new_rel
+                SET new_rel.asserted_by_sabs = apoc.coll.union(coalesce(new_rel.asserted_by_sabs, []), r.asserted_by_sabs),
+                    new_rel.last_seen_version = $version
+                RETURN count(*) AS out_rels
+            }
+            // Migrate incoming relationships
+            CALL {
+                WITH old, new
+                MATCH (source:Concept)-[r]->(old) WHERE source <> new
+                CALL apoc.merge.relationship(source, type(r), {source_rela: r.source_rela}, {}, new) YIELD rel AS new_rel
+                SET new_rel.asserted_by_sabs = apoc.coll.union(coalesce(new_rel.asserted_by_sabs, []), r.asserted_by_sabs),
+                    new_rel.last_seen_version = $version
+                RETURN count(*) AS in_rels
+            }
+            // Migrate codes
+            CALL {
+                WITH old, new
+                MATCH (old)-[r:HAS_CODE]->(c:Code)
+                MERGE (new)-[new_r:HAS_CODE]->(c)
+                SET new_r.last_seen_version = $version
+                RETURN count(*) AS code_rels
+            }
+            // Finally, delete the old, now-isolated concept
+            DETACH DELETE old
+          ',
+          {batchSize: 5, parallel: false, params: {merges: $merges, version: $version}}
         )
         """
-        self._run_query(query, params={"merges": merges})
+        self._run_query(query, params={"merges": merges, "version": self.new_version})
         console.log(f"Submitted merge task for {len(merges)} CUI pairs.")
 
     def apply_additions_and_updates(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,27 +5,6 @@ from pathlib import Path
 import shutil
 
 @pytest.fixture(scope="session")
-def neo4j_container():
-    """
-    A pytest fixture that starts and stops a Neo4j container for the test session.
-    The container is configured with APOC plugins.
-    """
-    # Use the fluent API (`.with_...` methods) to avoid constructor conflicts.
-    container = Neo4jContainer(image="neo4j:5.18")
-    container.with_env("NEO4J_PLUGINS", '["apoc"]')
-    container.with_env("NEO4J_apoc_export_file_enabled", "true")
-    container.with_env("NEO4J_apoc_import_file_enabled", "true")
-    container.with_env("NEO4J_apoc_import_file_use__neo4j__config", "true")
-    container.with_env("NEO4J_dbms_security_procedures_unrestricted", "apoc.*")
-    container.with_env("NEO4J_AUTH", "neo4j/password") # Explicitly set for clarity
-
-    with container as c:
-        c.driver = c.get_driver()
-        yield c
-        c.driver.close()
-
-
-@pytest.fixture(scope="session")
 def session_tmp_path(tmpdir_factory):
     """A session-scoped temporary directory."""
     return tmpdir_factory.mktemp("data")


### PR DESCRIPTION
The previous implementation used `apoc.refactor.mergeNodes` to handle CUI merges from `MERGEDCUI.RRF`. This procedure does not support the custom logic required by the FRD for merging relationship properties. Specifically, if a relationship already existed on the target concept, the provenance (`asserted_by_sabs` list) from the source concept's relationship was lost.

This commit replaces the `apoc.refactor.mergeNodes` call with a more detailed Cypher query that manually migrates relationships. It uses `apoc.merge.relationship` and `apoc.coll.union` to ensure that when a relationship is migrated to a concept that already has a similar relationship, their `asserted_by_sabs` lists are correctly combined.

In addition to this primary fix, this commit also includes:
- A fix for a duplicated pytest fixture in `tests/conftest.py`.
- A correction to the graph schema description in `README.md`.